### PR TITLE
Padronizando nomeação das pastas.

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,7 +2,7 @@ import { HandlebarsAdapter, MailerModule } from '@nest-modules/mailer';
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { database } from './config/database';
+import { database } from './Config/database';
 import { SecurityModule } from './SecurityModule';
 import { UserModule } from './UserModule';
 import { TypeOrmModule } from '@nestjs/typeorm';


### PR DESCRIPTION
Estava Nomeado com letra minuscula, alterado para o padrão das demais.