### PR TITLE
Corrigido url do swagger no README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Você pode rodar o projeto direto da sua máquina.
 
 4- Veja o swagger pelo navegador
 
->**http://localhost:3000/api/**
+>**http://localhost:3000/swagger**
 
 ## Docker
 


### PR DESCRIPTION
Feito ajuste na documentação com a url correta do swagger. 