### PR TITLE
Adicionado suporte a transações em rotas com acesso ao banco de dados

### DIFF
--- a/src/CertificateModule/controller/certificate.controller.ts
+++ b/src/CertificateModule/controller/certificate.controller.ts
@@ -11,7 +11,6 @@ import {
   ApiUnauthorizedResponse,
   ApiUseTags,
 } from '@nestjs/swagger';
-import { Transactional } from 'typeorm-transactional-cls-hooked';
 import { CertificateService } from '../service';
 import { CertificateMapper } from '../mapper';
 import { CertificateDTO, NewCertificateDTO } from '../dto';
@@ -31,7 +30,6 @@ export class CertificateController {
 
   @Get()
   @HttpCode(200)
-  @Transactional()
   @ApiOperation({ title: 'Get Certificates', description: 'Get all certificates' })
   @ApiOkResponse({ type: CertificateDTO, isArray: true, description: 'All certificates' })
   @ApiUnauthorizedResponse({ description: 'thrown if there is not an authorization token or if authorization token does not have ADMIN or STUDENT role' })
@@ -43,7 +41,6 @@ export class CertificateController {
 
   @Post()
   @HttpCode(201)
-  @Transactional()
   @ApiCreatedResponse({ type: CertificateDTO, description: 'Created certificate' })
   @ApiOperation({ title: 'Add certificate', description: 'Creates a new certificate' })
   @ApiImplicitBody({ name: 'certificate', type: NewCertificateDTO })
@@ -58,7 +55,6 @@ export class CertificateController {
 
   @Put('/:id')
   @HttpCode(200)
-  @Transactional()
   @ApiImplicitQuery({ name: 'id', type: Number, required: true, description: 'Certificate id' })
   @ApiOperation({ title: 'Update certificate', description: 'Update certificate by id' })
   @ApiOkResponse({ type: NewCertificateDTO })
@@ -77,7 +73,6 @@ export class CertificateController {
 
   @Get('/:id')
   @HttpCode(200)
-  @Transactional()
   @ApiImplicitQuery({ name: 'id', type: Number, required: true, description: 'Certificate Id' })
   @ApiOperation({ title: 'Find certificate by id', description: 'Find certificate by id' })
   @ApiNotFoundResponse({ description: 'thrown if certificate is not found' })
@@ -92,7 +87,6 @@ export class CertificateController {
 
   @Delete('/:id')
   @HttpCode(200)
-  @Transactional()
   @ApiImplicitQuery({ name: 'id', type: Number, required: true, description: 'Certificate id' })
   @ApiOperation({ title: 'Delete certificate', description: 'Delete certificate by id' })
   @ApiOkResponse({ type: null })

--- a/src/CertificateModule/controller/certificate.controller.ts
+++ b/src/CertificateModule/controller/certificate.controller.ts
@@ -11,6 +11,7 @@ import {
   ApiUnauthorizedResponse,
   ApiUseTags,
 } from '@nestjs/swagger';
+import { Transactional } from 'typeorm-transactional-cls-hooked';
 import { CertificateService } from '../service';
 import { CertificateMapper } from '../mapper';
 import { CertificateDTO, NewCertificateDTO } from '../dto';
@@ -30,6 +31,7 @@ export class CertificateController {
 
   @Get()
   @HttpCode(200)
+  @Transactional()
   @ApiOperation({ title: 'Get Certificates', description: 'Get all certificates' })
   @ApiOkResponse({ type: CertificateDTO, isArray: true, description: 'All certificates' })
   @ApiUnauthorizedResponse({ description: 'thrown if there is not an authorization token or if authorization token does not have ADMIN or STUDENT role' })
@@ -41,6 +43,7 @@ export class CertificateController {
 
   @Post()
   @HttpCode(201)
+  @Transactional()
   @ApiCreatedResponse({ type: CertificateDTO, description: 'Created certificate' })
   @ApiOperation({ title: 'Add certificate', description: 'Creates a new certificate' })
   @ApiImplicitBody({ name: 'certificate', type: NewCertificateDTO })
@@ -55,6 +58,7 @@ export class CertificateController {
 
   @Put('/:id')
   @HttpCode(200)
+  @Transactional()
   @ApiImplicitQuery({ name: 'id', type: Number, required: true, description: 'Certificate id' })
   @ApiOperation({ title: 'Update certificate', description: 'Update certificate by id' })
   @ApiOkResponse({ type: NewCertificateDTO })
@@ -73,6 +77,7 @@ export class CertificateController {
 
   @Get('/:id')
   @HttpCode(200)
+  @Transactional()
   @ApiImplicitQuery({ name: 'id', type: Number, required: true, description: 'Certificate Id' })
   @ApiOperation({ title: 'Find certificate by id', description: 'Find certificate by id' })
   @ApiNotFoundResponse({ description: 'thrown if certificate is not found' })
@@ -87,6 +92,7 @@ export class CertificateController {
 
   @Delete('/:id')
   @HttpCode(200)
+  @Transactional()
   @ApiImplicitQuery({ name: 'id', type: Number, required: true, description: 'Certificate id' })
   @ApiOperation({ title: 'Delete certificate', description: 'Delete certificate by id' })
   @ApiOkResponse({ type: null })

--- a/src/CertificateModule/service/certificate.service.ts
+++ b/src/CertificateModule/service/certificate.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
+import { Transactional } from 'typeorm-transactional-cls-hooked';
 import { CertificateRepository } from '../repository';
 import { Certificate } from '../entity';
 import { CertificateDTO, NewCertificateDTO } from '../dto';
@@ -11,14 +12,17 @@ export class CertificateService {
   ) {
   }
 
+  @Transactional()
   public async findAll(): Promise<Certificate[]> {
     return this.repository.find();
   }
 
+  @Transactional()
   async save(certificate: NewCertificateDTO): Promise<Certificate> {
     return await this.repository.save(certificate);
   }
 
+  @Transactional()
   public async findById(id: Certificate['id']): Promise<Certificate> {
     const foundCertificate: Certificate | undefined = await this.repository.findById(id);
     if (!foundCertificate) {
@@ -27,11 +31,13 @@ export class CertificateService {
     return foundCertificate;
   }
 
+  @Transactional()
   public async update(id: Certificate['id'], certificate: CertificateDTO): Promise<Certificate> {
     const foundCertificate: Certificate = await this.findById(id);
     return this.save({ ...foundCertificate, ...certificate });
   }
 
+  @Transactional()
   public async delete(id: Certificate['id']) {
     await this.findById(id);
     await this.repository.delete({ id });

--- a/src/CourseModule/controllers/course.controller.ts
+++ b/src/CourseModule/controllers/course.controller.ts
@@ -1,4 +1,5 @@
 import { Body, Controller, Delete, Get, HttpCode, Param, Post, Put, UseGuards } from '@nestjs/common';
+import { Transactional } from 'typeorm-transactional-cls-hooked';
 import { CourseService } from '../service';
 import { Constants, NeedRole, RoleGuard } from '../../CommonsModule';
 import { CourseDTO, CourseUpdateDTO, NewCourseDTO } from '../dto';
@@ -26,6 +27,7 @@ export class CourseController {
 
   @Get()
   @HttpCode(200)
+  @Transactional()
   @ApiOperation({ title: 'Get Courses', description: 'Get all Courses' })
   @ApiOkResponse({ type: CourseDTO, isArray: true, description: 'All Courses' })
   @NeedRole(RoleEnum.ADMIN, RoleEnum.STUDENT)
@@ -36,6 +38,7 @@ export class CourseController {
 
   @Get('/:id')
   @HttpCode(200)
+  @Transactional()
   @ApiOkResponse({ type: CourseDTO })
   @ApiImplicitQuery({ name: 'id', type: Number, required: true, description: 'Course id' })
   @ApiOperation({ title: 'Find Course by id', description: 'Find Course by id' })
@@ -47,6 +50,7 @@ export class CourseController {
 
   @Get('/slug/:slug')
   @HttpCode(200)
+  @Transactional()
   @ApiOkResponse({ type: CourseDTO })
   @ApiImplicitQuery({ name: 'slug', type: String, required: true, description: 'Course slug' })
   @ApiOperation({ title: 'Find Course by slug', description: 'Find Course by slug' })
@@ -58,6 +62,7 @@ export class CourseController {
 
   @Post()
   @HttpCode(201)
+  @Transactional()
   @ApiCreatedResponse({ type: CourseDTO, description: 'Course created' })
   @ApiOperation({ title: 'Add course', description: 'Creates a new course' })
   @ApiImplicitBody({ name: 'Course', type: NewCourseDTO })
@@ -71,6 +76,7 @@ export class CourseController {
 
   @Put('/:id')
   @HttpCode(200)
+  @Transactional()
   @ApiOkResponse({ type: CourseDTO })
   @ApiImplicitQuery({ name: 'id', type: Number, required: true, description: 'Course id' })
   @ApiOperation({ title: 'Update course', description: 'Update course by id' })
@@ -82,6 +88,7 @@ export class CourseController {
 
   @Delete('/:id')
   @HttpCode(200)
+  @Transactional()
   @ApiOkResponse({ type: null })
   @ApiImplicitQuery({ name: 'id', type: Number, required: true, description: 'Course id' })
   @ApiOperation({ title: 'Delete course', description: 'Delete course by id' })
@@ -90,6 +97,4 @@ export class CourseController {
   public async delete(@Param('id') id: CourseDTO['id']): Promise<void> {
     await this.service.delete(id);
   }
-
-
 }

--- a/src/CourseModule/controllers/course.controller.ts
+++ b/src/CourseModule/controllers/course.controller.ts
@@ -1,5 +1,4 @@
 import { Body, Controller, Delete, Get, HttpCode, Param, Post, Put, UseGuards } from '@nestjs/common';
-import { Transactional } from 'typeorm-transactional-cls-hooked';
 import { CourseService } from '../service';
 import { Constants, NeedRole, RoleGuard } from '../../CommonsModule';
 import { CourseDTO, CourseUpdateDTO, NewCourseDTO } from '../dto';
@@ -27,7 +26,6 @@ export class CourseController {
 
   @Get()
   @HttpCode(200)
-  @Transactional()
   @ApiOperation({ title: 'Get Courses', description: 'Get all Courses' })
   @ApiOkResponse({ type: CourseDTO, isArray: true, description: 'All Courses' })
   @NeedRole(RoleEnum.ADMIN, RoleEnum.STUDENT)
@@ -38,7 +36,6 @@ export class CourseController {
 
   @Get('/:id')
   @HttpCode(200)
-  @Transactional()
   @ApiOkResponse({ type: CourseDTO })
   @ApiImplicitQuery({ name: 'id', type: Number, required: true, description: 'Course id' })
   @ApiOperation({ title: 'Find Course by id', description: 'Find Course by id' })
@@ -50,7 +47,6 @@ export class CourseController {
 
   @Get('/slug/:slug')
   @HttpCode(200)
-  @Transactional()
   @ApiOkResponse({ type: CourseDTO })
   @ApiImplicitQuery({ name: 'slug', type: String, required: true, description: 'Course slug' })
   @ApiOperation({ title: 'Find Course by slug', description: 'Find Course by slug' })
@@ -62,7 +58,6 @@ export class CourseController {
 
   @Post()
   @HttpCode(201)
-  @Transactional()
   @ApiCreatedResponse({ type: CourseDTO, description: 'Course created' })
   @ApiOperation({ title: 'Add course', description: 'Creates a new course' })
   @ApiImplicitBody({ name: 'Course', type: NewCourseDTO })
@@ -76,7 +71,6 @@ export class CourseController {
 
   @Put('/:id')
   @HttpCode(200)
-  @Transactional()
   @ApiOkResponse({ type: CourseDTO })
   @ApiImplicitQuery({ name: 'id', type: Number, required: true, description: 'Course id' })
   @ApiOperation({ title: 'Update course', description: 'Update course by id' })
@@ -88,7 +82,6 @@ export class CourseController {
 
   @Delete('/:id')
   @HttpCode(200)
-  @Transactional()
   @ApiOkResponse({ type: null })
   @ApiImplicitQuery({ name: 'id', type: Number, required: true, description: 'Course id' })
   @ApiOperation({ title: 'Delete course', description: 'Delete course by id' })

--- a/src/CourseModule/service/course.service.ts
+++ b/src/CourseModule/service/course.service.ts
@@ -1,4 +1,5 @@
 import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import { Transactional } from 'typeorm-transactional-cls-hooked';
 import { CourseRepository } from '../repository';
 import { Course } from '../entity';
 import { CourseDTO, CourseUpdateDTO } from '../dto';
@@ -13,6 +14,7 @@ export class CourseService {
   ) {
   }
 
+  @Transactional()
   public async add(course: Course): Promise<Course> {
 
     const courseSameTitle: Course = await this.repository.findByTitle(course.title);
@@ -23,16 +25,18 @@ export class CourseService {
     return this.repository.save(course);
   }
 
+  @Transactional()
   public async update(id: Course['id'], userUpdatedInfo: CourseUpdateDTO): Promise<Course> {
     const course: Course = await this.findById(id);
     return this.repository.save(this.mapper.toEntity({ ...course, ...userUpdatedInfo } as unknown as CourseDTO));
   }
 
-
+  @Transactional()
   public async getAll(): Promise<Course[]> {
     return this.repository.find();
   }
 
+  @Transactional()
   public async findById(id: Course['id']): Promise<Course> {
     const course: Course = await this.repository.findOne(id);
     if (!course) {
@@ -41,6 +45,7 @@ export class CourseService {
     return course;
   }
 
+  @Transactional()
   public async findBySlug(slug: string): Promise<Course> {
     const course: Course = await this.repository.findBySlug(slug);
     if (!course) {
@@ -49,10 +54,12 @@ export class CourseService {
     return course;
   }
 
+  @Transactional()
   public async delete(id: Course['id']): Promise<void> {
     await this.repository.delete(id);
   }
 
+  @Transactional()
   public async findByTitle(title: string): Promise<Course> {
     const course = await this.repository.findByTitle(title);
     if (!course) {

--- a/src/SecurityModule/controller/security.controller.ts
+++ b/src/SecurityModule/controller/security.controller.ts
@@ -8,7 +8,6 @@ import {
   UnauthorizedException,
   UseInterceptors,
 } from '@nestjs/common';
-import { Transactional } from 'typeorm-transactional-cls-hooked';
 import { SecurityService } from '../service';
 import { Constants } from '../../CommonsModule';
 import { AuthDTO, GeneratedTokenDTO } from '../dto';
@@ -30,7 +29,6 @@ export class SecurityController {
   @UseInterceptors(FileInterceptor(''))
   @Post('/token')
   @HttpCode(200)
-  @Transactional()
   async authenticateUser(
     // eslint-disable-next-line @typescript-eslint/camelcase
     @Body() { grant_type, username, password, refresh_token }: AuthDTO,

--- a/src/SecurityModule/controller/security.controller.ts
+++ b/src/SecurityModule/controller/security.controller.ts
@@ -8,6 +8,7 @@ import {
   UnauthorizedException,
   UseInterceptors,
 } from '@nestjs/common';
+import { Transactional } from 'typeorm-transactional-cls-hooked';
 import { SecurityService } from '../service';
 import { Constants } from '../../CommonsModule';
 import { AuthDTO, GeneratedTokenDTO } from '../dto';
@@ -29,13 +30,15 @@ export class SecurityController {
   @UseInterceptors(FileInterceptor(''))
   @Post('/token')
   @HttpCode(200)
+  @Transactional()
   async authenticateUser(
     // eslint-disable-next-line @typescript-eslint/camelcase
     @Body() { grant_type, username, password, refresh_token }: AuthDTO,
     @Headers('authorization') authorization: string,
   ): Promise<GeneratedTokenDTO> {
-    if (!authorization)
+    if (!authorization) {
       throw new UnauthorizedException();
+    }
 
     // eslint-disable-next-line @typescript-eslint/camelcase
     this.logger.log(`grant_type: ${grant_type}`);

--- a/src/SecurityModule/service/role.service.ts
+++ b/src/SecurityModule/service/role.service.ts
@@ -2,6 +2,7 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { RoleEnum } from '../enum';
 import { RoleRepository } from '../repository';
 import { Role } from '../entity';
+import { Transactional } from 'typeorm-transactional-cls-hooked';
 
 @Injectable()
 export class RoleService {
@@ -10,6 +11,7 @@ export class RoleService {
   ) {
   }
 
+  @Transactional()
   public async findByRoleName(name: RoleEnum): Promise<Role> {
     const role: Role = await this.repository.findByRoleName(name);
     if (!role) {

--- a/src/SecurityModule/service/security.service.ts
+++ b/src/SecurityModule/service/security.service.ts
@@ -9,6 +9,7 @@ import { UserService } from '../../UserModule/service';
 import { ClientCredentialsRepository, RoleRepository } from '../repository';
 import { JwtService } from '@nestjs/jwt';
 import { User } from '../../UserModule/entity';
+import { Transactional } from 'typeorm-transactional-cls-hooked';
 
 @Injectable()
 export class SecurityService {
@@ -21,6 +22,7 @@ export class SecurityService {
   ) {
   }
 
+  @Transactional()
   public async validateClientCredentials(base64Login: string): Promise<GeneratedTokenDTO> {
     const [name, secret]: string[] = this.splitClientCredentials(
       this.base64ToString(base64Login),
@@ -32,6 +34,7 @@ export class SecurityService {
     return this.generateLoginObject(clientCredentials);
   }
 
+  @Transactional()
   public decodeToken(jwt: string): ClientCredentials | User {
     return this.jwtService.verify<ClientCredentials | User>(jwt);
   }
@@ -45,6 +48,7 @@ export class SecurityService {
       .toString('ascii');
   }
 
+  @Transactional()
   public async validateUserCredentials(base64Login: string, username: string, password: string): Promise<GeneratedTokenDTO> {
     const [name, secret]: string[] = this.splitClientCredentials(
       this.base64ToString(base64Login),
@@ -57,6 +61,7 @@ export class SecurityService {
     return this.generateLoginObject(user);
   }
 
+  @Transactional()
   public async refreshToken(base64Login: string, refreshToken: string): Promise<GeneratedTokenDTO> {
     const [name, secret]: string[] = this.splitClientCredentials(
       this.base64ToString(base64Login),

--- a/src/UserModule/controller/user.controller.ts
+++ b/src/UserModule/controller/user.controller.ts
@@ -52,7 +52,6 @@ export class UserController {
 
   @Get()
   @HttpCode(200)
-  @Transactional()
   @ApiOperation({ title: 'Get Users', description: 'Get all users' })
   @ApiOkResponse({ type: NewUserDTO, isArray: true, description: 'All users' })
   @ApiUnauthorizedResponse({ description: 'thrown if there is not an authorization token or if authorization token does not have ADMIN role' })
@@ -64,7 +63,6 @@ export class UserController {
 
   @Get('/me')
   @HttpCode(200)
-  @Transactional()
   @ApiOkResponse({ type: NewUserDTO })
   @ApiImplicitQuery({ name: 'id', type: Number, required: true, description: 'User id' })
   @ApiOperation({ title: 'Find user by jwt id', description: 'Decodes de jwt and finds the user by the jwt id' })
@@ -82,7 +80,6 @@ export class UserController {
 
   @Get('/:id')
   @HttpCode(200)
-  @Transactional()
   @ApiOkResponse({ type: NewUserDTO })
   @ApiImplicitQuery({ name: 'id', type: Number, required: true, description: 'User id' })
   @ApiOperation({ title: 'Find user by id', description: 'Find user by id' })
@@ -113,7 +110,6 @@ export class UserController {
 
   @Put(':id')
   @HttpCode(200)
-  @Transactional()
   @ApiImplicitQuery({ name: 'id', type: Number, required: true, description: 'User id' })
   @ApiOperation({ title: 'Update user', description: 'Update user by id' })
   @ApiOkResponse({ type: UserDTO })
@@ -148,7 +144,6 @@ export class UserController {
 
   @Get('/forgot-password/:changePasswordRequestId/validate')
   @HttpCode(200)
-  @Transactional()
   @ApiOperation({
     title: 'Validate change password request',
     description: 'validate change password expiration time. If time is not expired, 200 is returned',
@@ -165,7 +160,6 @@ export class UserController {
 
   @Post('/forgot-password/:changePasswordRequestId')
   @HttpCode(200)
-  @Transactional()
   @ApiOperation({
     title: 'change password',
   })
@@ -182,7 +176,6 @@ export class UserController {
   }
 
   @Post('/:userId/certificate/:certificateId')
-  @Transactional()
   public async addCertificateToUser(
     @Param('userId') userId: string,
     @Param('certificateId') certificateId: string,
@@ -193,7 +186,6 @@ export class UserController {
 
   @Delete('/:id')
   @HttpCode(200)
-  @Transactional()
   @ApiImplicitQuery({ name: 'id', type: Number, required: true, description: 'User id' })
   @ApiOperation({ title: 'Delete user', description: 'Delete user by id' })
   @ApiOkResponse({ type: null })

--- a/src/UserModule/controller/user.controller.ts
+++ b/src/UserModule/controller/user.controller.ts
@@ -13,6 +13,7 @@ import {
   Put,
   UseGuards,
 } from '@nestjs/common';
+import { Transactional } from 'typeorm-transactional-cls-hooked';
 import { UserService } from '../service';
 import { Constants, NeedRole, RoleGuard } from '../../CommonsModule';
 import { ChangePasswordRequestIdDTO, ForgotPasswordDTO, NewUserDTO, UserDTO, UserUpdateDTO } from '../dto';
@@ -51,6 +52,7 @@ export class UserController {
 
   @Get()
   @HttpCode(200)
+  @Transactional()
   @ApiOperation({ title: 'Get Users', description: 'Get all users' })
   @ApiOkResponse({ type: NewUserDTO, isArray: true, description: 'All users' })
   @ApiUnauthorizedResponse({ description: 'thrown if there is not an authorization token or if authorization token does not have ADMIN role' })
@@ -62,6 +64,7 @@ export class UserController {
 
   @Get('/me')
   @HttpCode(200)
+  @Transactional()
   @ApiOkResponse({ type: NewUserDTO })
   @ApiImplicitQuery({ name: 'id', type: Number, required: true, description: 'User id' })
   @ApiOperation({ title: 'Find user by jwt id', description: 'Decodes de jwt and finds the user by the jwt id' })
@@ -79,6 +82,7 @@ export class UserController {
 
   @Get('/:id')
   @HttpCode(200)
+  @Transactional()
   @ApiOkResponse({ type: NewUserDTO })
   @ApiImplicitQuery({ name: 'id', type: Number, required: true, description: 'User id' })
   @ApiOperation({ title: 'Find user by id', description: 'Find user by id' })
@@ -95,6 +99,7 @@ export class UserController {
 
   @Post()
   @HttpCode(201)
+  @Transactional()
   @ApiCreatedResponse({ type: NewUserDTO, description: 'User created' })
   @ApiOperation({ title: 'Add user', description: 'Creates a new user' })
   @ApiImplicitBody({ name: 'User', type: NewUserSwagger })
@@ -108,6 +113,7 @@ export class UserController {
 
   @Put(':id')
   @HttpCode(200)
+  @Transactional()
   @ApiImplicitQuery({ name: 'id', type: Number, required: true, description: 'User id' })
   @ApiOperation({ title: 'Update user', description: 'Update user by id' })
   @ApiOkResponse({ type: UserDTO })
@@ -125,6 +131,7 @@ export class UserController {
 
   @Post('/forgot-password')
   @HttpCode(200)
+  @Transactional()
   @ApiOkResponse({ type: ChangePasswordRequestIdDTO })
   @ApiOperation({ title: 'Create change password request', description: 'Create change password request' })
   @ApiNotFoundResponse({ description: 'thrown if user is not found' })
@@ -141,6 +148,7 @@ export class UserController {
 
   @Get('/forgot-password/:changePasswordRequestId/validate')
   @HttpCode(200)
+  @Transactional()
   @ApiOperation({
     title: 'Validate change password request',
     description: 'validate change password expiration time. If time is not expired, 200 is returned',
@@ -157,6 +165,7 @@ export class UserController {
 
   @Post('/forgot-password/:changePasswordRequestId')
   @HttpCode(200)
+  @Transactional()
   @ApiOperation({
     title: 'change password',
   })
@@ -173,6 +182,7 @@ export class UserController {
   }
 
   @Post('/:userId/certificate/:certificateId')
+  @Transactional()
   public async addCertificateToUser(
     @Param('userId') userId: string,
     @Param('certificateId') certificateId: string,
@@ -183,6 +193,7 @@ export class UserController {
 
   @Delete('/:id')
   @HttpCode(200)
+  @Transactional()
   @ApiImplicitQuery({ name: 'id', type: Number, required: true, description: 'User id' })
   @ApiOperation({ title: 'Delete user', description: 'Delete user by id' })
   @ApiOkResponse({ type: null })

--- a/src/UserModule/service/user.service.ts
+++ b/src/UserModule/service/user.service.ts
@@ -19,6 +19,7 @@ import { Certificate } from '../../CertificateModule/entity';
 import { CertificateService } from '../../CertificateModule/service';
 import { RoleService } from '../../SecurityModule/service';
 import { Role } from '../../SecurityModule/entity';
+import { Transactional } from 'typeorm-transactional-cls-hooked';
 
 @Injectable()
 export class UserService {
@@ -33,10 +34,12 @@ export class UserService {
   ) {
   }
 
+  @Transactional()
   public async getAll(): Promise<User[]> {
     return this.repository.find();
   }
 
+  @Transactional()
   public async findById(id: User['id']): Promise<User> {
     const user: User | undefined = await this.repository.findOne(id);
     if (!user) {
@@ -61,11 +64,13 @@ export class UserService {
     });
   }
 
+  @Transactional()
   public async delete(id: User['id']): Promise<void> {
     await this.findById(id);
     await this.repository.delete(id);
   }
 
+  @Transactional()
   public async update(id: User['id'], userUpdatedInfo: User): Promise<User> {
     const user: User = await this.findById(id);
     return this.repository.save({ ...user, ...userUpdatedInfo });
@@ -78,6 +83,7 @@ export class UserService {
     return changePassword.id;
   }
 
+  @Transactional()
   public async findByEmail(email: string): Promise<User> {
     const user: User = await this.repository.findByEmail(email);
     if (!user) {
@@ -86,6 +92,7 @@ export class UserService {
     return user;
   }
 
+  @Transactional()
   public async findByEmailAndPassword(email: string, password: string): Promise<User> {
     const user: User = await this.findByEmail(email);
     if (!user.validPassword(password)) {
@@ -94,6 +101,7 @@ export class UserService {
     return user;
   }
 
+  @Transactional()
   public async validateChangePassword(changePasswordRequestId: string) {
     const changePassword: ChangePassword = await this.changePasswordService.findById(changePasswordRequestId);
     if (Date.now() > new Date(changePassword.createdAt).getTime() + changePassword.expirationTime) {
@@ -101,6 +109,7 @@ export class UserService {
     }
   }
 
+  @Transactional()
   public async changePassword(changePasswordRequestId: string, changePasswordDTO: ChangePasswordDTO) {
     if (changePasswordDTO.password !== changePasswordDTO.validatePassword) {
       throw new BadRequestException();
@@ -111,6 +120,7 @@ export class UserService {
     await this.repository.save(user);
   }
 
+  @Transactional()
   public async addCertificateToUser(userId: User['id'], certificateId: Certificate['id']) {
     const [user, certificate]: [User, Certificate] = await Promise.all([
       this.repository.findByIdWithCertificates(userId),

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,10 +3,15 @@ import { ConfigService } from '@nestjs/config';
 import { AppModule } from './app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { ValidationPipe } from '@nestjs/common';
+import { initializeTransactionalContext, patchTypeORMRepositoryWithBaseRepository } from 'typeorm-transactional-cls-hooked';
 import { HttpExceptionFilter } from './CommonsModule/httpFilter/http-exception.filter';
+import 'reflect-metadata';
 
 async function bootstrap() {
   require('dotenv-flow').config();
+
+  initializeTransactionalContext();
+  patchTypeORMRepositoryWithBaseRepository();
 
   const appOptions = { cors: true };
   const app = await NestFactory.create(AppModule, appOptions);


### PR DESCRIPTION
Implantação do suporte a transações pela camada de serviços, com a utilização do pacote auxiliar typeorm-transaction-cls-hooked (https://github.com/odavid/typeorm-transactional-cls-hooked).

Obs.: Devido a problemas de dependência circular no Nest, foi necessário abrir exceções para as ações de adicionar usuário e esqueci a senha, onde as transações foram aplicadas nos métodos dos controllers ao invés dos serviços.

Tarefa no Trello: https://trello.com/c/rCFPMpMN/28-adicionar-possibilidade-de-transa%C3%A7%C3%A3o-dentro-da-camada-de-servi%C3%A7os