### PR TITLE
fix: added role external to get certificate

### DIFF
--- a/src/CourseTakenModule/controllers/course.taken.controller.ts
+++ b/src/CourseTakenModule/controllers/course.taken.controller.ts
@@ -261,7 +261,7 @@ export class CourseTakenController {
     summary: 'Find certificates by user and course',
     description: 'Find certificates by user id and course id',
   })
-  @NeedRole(RoleEnum.ADMIN, RoleEnum.STUDENT)
+  @NeedRole(RoleEnum.ADMIN, RoleEnum.STUDENT, RoleEnum.EXTERNAL)
   @UseGuards(RoleGuard)
   public async getCertificate(
     @Param('userId') userId: CourseTakenDTO['user'],


### PR DESCRIPTION
Corrigido rota para carregar os dados de um certificado para poder ser consultado com a Role external, pois isso é necessário para o certificado ser público.